### PR TITLE
Add optional noDuplicates flag to Excel import workflow

### DIFF
--- a/plugins/excelimport/src/main/java/de/bund/zrb/excel/controller/ExcelImportController.java
+++ b/plugins/excelimport/src/main/java/de/bund/zrb/excel/controller/ExcelImportController.java
@@ -52,6 +52,7 @@ public class ExcelImportController {
         importParameters.put("hasHeader", ui.isHeaderEnabled());
         importParameters.put("headerRowIndex", ui.getHeaderRowIndex());
         importParameters.put("append", ui.shouldAppend());
+        importParameters.put("noDuplicates", ui.shouldSkipDuplicates());
         importParameters.put("trennzeile", ui.getTrennzeile());
 
         ExcelImportConfig config = new ExcelImportConfig(
@@ -120,6 +121,7 @@ public class ExcelImportController {
                 .map(List::size)
                 .orElse(0);
 
+        String previousRecord = null;
         for (int i = 0; i < rowCount; i++) {
             Function<String, String> valueProvider = createValueResolver(registry, excelData, mapping, i);
 
@@ -130,7 +132,12 @@ public class ExcelImportController {
                     valueProvider
             );
 
+            if (config.isNoDuplicates() && Objects.equals(previousRecord, record)) {
+                continue;
+            }
+
             builder.append(record).append("\n");
+            previousRecord = record;
         }
 
         String result = builder.toString().trim();

--- a/plugins/excelimport/src/main/java/de/bund/zrb/excel/mcp/ImportExcelTool.java
+++ b/plugins/excelimport/src/main/java/de/bund/zrb/excel/mcp/ImportExcelTool.java
@@ -30,6 +30,7 @@ public class ImportExcelTool implements McpTool {
         properties.put("hasHeader", new ToolSpec.Property("boolean", "Ob Spaltennamen in einer Kopfzeile vorhanden sind"));
         properties.put("headerRowIndex", new ToolSpec.Property("integer", "Index der Kopfzeile (beginnend bei 0)"));
         properties.put("append", new ToolSpec.Property("boolean", "Ob an eine bestehende Datei angehängt wird"));
+        properties.put("noDuplicates", new ToolSpec.Property("boolean", "Unterdrückt aufeinanderfolgende identische Datensätze"));
         properties.put("separator", new ToolSpec.Property("string", "Text der Trennzeile (optional)"));
         properties.put("search", new ToolSpec.Property("string", "Suchausdruck innerhalb des Ziels hervorheben"));
         properties.put("toCompare", new ToolSpec.Property("boolean", "Vergleich mit dem alten Inhalt öffnen"));
@@ -44,6 +45,7 @@ public class ImportExcelTool implements McpTool {
         example.put("hasHeader", true);
         example.put("headerRowIndex", 0);
         example.put("append", false);
+        example.put("noDuplicates", false);
         example.put("separator", "");
         example.put("search", ".*ABC.*");
         example.put("toCompare", true);

--- a/plugins/excelimport/src/main/java/de/bund/zrb/excel/model/ExcelImportConfig.java
+++ b/plugins/excelimport/src/main/java/de/bund/zrb/excel/model/ExcelImportConfig.java
@@ -14,6 +14,7 @@ public class ExcelImportConfig {
     private boolean hasHeader = true;
     private int headerRowIndex = 0;
     private boolean append = false;
+    private boolean noDuplicates = false;
     private String separator = "";
 
     public String getSearchPattern() {
@@ -75,6 +76,14 @@ public class ExcelImportConfig {
         this.separator = separator;
     }
 
+    public boolean isNoDuplicates() {
+        return noDuplicates;
+    }
+
+    public void setNoDuplicates(boolean noDuplicates) {
+        this.noDuplicates = noDuplicates;
+    }
+
     public File getFile() {
         return file;
     }
@@ -115,6 +124,7 @@ public class ExcelImportConfig {
             this.hasHeader = optionalBoolean("hasHeader", input, schema, this.hasHeader);
             this.headerRowIndex = optionalInteger("headerRowIndex", input, schema, this.headerRowIndex);
             this.append = optionalBoolean("append", input, schema, this.append);
+            this.noDuplicates = optionalBoolean("noDuplicates", input, schema, this.noDuplicates);
             this.separator = optionalString("separator", input, schema, this.separator);
             this.searchPattern = optionalString("search", input, schema, this.searchPattern);
             this.toCompare = optionalBoolean("toCompare", input, schema, this.toCompare);

--- a/plugins/excelimport/src/main/java/de/bund/zrb/excel/ui/ExcelImportUiPanel.java
+++ b/plugins/excelimport/src/main/java/de/bund/zrb/excel/ui/ExcelImportUiPanel.java
@@ -21,6 +21,7 @@ public class ExcelImportUiPanel extends JPanel {
     private static final String KEY_HEADER_ENABLED = "headerEnabled";
     private static final String KEY_HEADER_ROW = "headerRow";
     private static final String KEY_APPEND = "append";
+    private static final String KEY_NO_DUPLICATES = "noDuplicates";
     private static final String KEY_TRENNZEILE = "separator";
     private String lastSaved;
 
@@ -36,6 +37,7 @@ public class ExcelImportUiPanel extends JPanel {
     private final JButton templateEditButton = new JButton("...");
 
     private final JCheckBox appendCheckbox = new JCheckBox("An bestehende Datei anhängen");
+    private final JCheckBox noDuplicatesCheckbox = new JCheckBox("Aufeinanderfolgende Duplikate überspringen");
     private final JTextField trennzeileField = new JTextField();
     private final TemplateRepository templateRepo;
 
@@ -102,7 +104,13 @@ public class ExcelImportUiPanel extends JPanel {
         gbc.gridwidth = 3;
         formPanel.add(appendCheckbox, gbc);
 
-        // Zeile 5: Trennzeile
+        // Zeile 5: Duplikate
+        gbc.gridx = 0;
+        gbc.gridy++;
+        gbc.gridwidth = 3;
+        formPanel.add(noDuplicatesCheckbox, gbc);
+
+        // Zeile 6: Trennzeile
         gbc.gridx = 0;
         gbc.gridy++;
         gbc.gridwidth = 1;
@@ -222,6 +230,9 @@ public class ExcelImportUiPanel extends JPanel {
         appendCheckbox.setSelected(Boolean.parseBoolean(settings.getOrDefault(KEY_APPEND, "false")));
         trennzeileField.setEnabled(appendCheckbox.isSelected());
 
+        // Duplikate
+        noDuplicatesCheckbox.setSelected(Boolean.parseBoolean(settings.getOrDefault(KEY_NO_DUPLICATES, "false")));
+
         // Trennzeile
         String trennzeile = settings.get(KEY_TRENNZEILE);
         if (trennzeile != null) {
@@ -239,6 +250,7 @@ public class ExcelImportUiPanel extends JPanel {
         settings.put(KEY_HEADER_ENABLED, Boolean.toString(headerCheckbox.isSelected()));
         settings.put(KEY_HEADER_ROW, String.valueOf(headerRowSpinner.getValue()));
         settings.put(KEY_APPEND, Boolean.toString(appendCheckbox.isSelected()));
+        settings.put(KEY_NO_DUPLICATES, Boolean.toString(noDuplicatesCheckbox.isSelected()));
         settings.put(KEY_TRENNZEILE, trennzeileField.getText());
 
         context.savePluginSettings(PLUGIN_KEY, settings);
@@ -283,6 +295,10 @@ public class ExcelImportUiPanel extends JPanel {
 
     public boolean shouldAppend() {
         return appendCheckbox.isSelected();
+    }
+
+    public boolean shouldSkipDuplicates() {
+        return noDuplicatesCheckbox.isSelected();
     }
 
     public String getTrennzeile() {


### PR DESCRIPTION
### Motivation
- Some target files receive identical rows when the Excel source contains repeated data, so an optional `noDuplicates` toggle is needed to suppress consecutive identical records during import.

### Description
- Added a new boolean `noDuplicates` field (default `false`) to `ExcelImportConfig` and wired it to be read from tool/workflow input via `optionalBoolean`.
- Extended the `import_excel` `ToolSpec` in `ImportExcelTool` with a `noDuplicates` property and example payload so the flag is usable from workflows/MCP calls.
- Added a checkbox `Aufeinanderfolgende Duplikate überspringen` to `ExcelImportUiPanel`, persisted via plugin settings, and passed into the import parameters as `noDuplicates`.
- Implemented deduplication in `ExcelImportController.importFromConfig` by keeping `previousRecord` and skipping appending when `config.isNoDuplicates()` and `Objects.equals(previousRecord, record)`.

### Testing
- Attempted to compile the plugin with `bash ./gradlew :plugins:excelimport:compileJava`, but the Gradle wrapper failed to download the distribution due to a network/proxy error (`HTTP/1.1 403 Forbidden`), so no build/compile verification could be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ecf591a883339200572b127980a4)