### PR TITLE
Add selectable Cloud AI provider with prefilled vendor defaults

### DIFF
--- a/app/src/main/java/de/bund/zrb/model/AiProvider.java
+++ b/app/src/main/java/de/bund/zrb/model/AiProvider.java
@@ -3,7 +3,7 @@ package de.bund.zrb.model;
 public enum AiProvider {
     DISABLED,
     OLLAMA,
+    CLOUD,
     LOCAL_AI,
     LLAMA_CPP_SERVER
 }
-

--- a/app/src/main/java/de/bund/zrb/service/CloudChatManager.java
+++ b/app/src/main/java/de/bund/zrb/service/CloudChatManager.java
@@ -1,0 +1,247 @@
+package de.bund.zrb.service;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import de.bund.zrb.helper.SettingsHelper;
+import de.bund.zrb.model.Settings;
+import de.bund.zrb.net.ProxyResolver;
+import de.bund.zrb.util.RetryInterceptor;
+import de.zrb.bund.api.ChatHistory;
+import de.zrb.bund.api.ChatManager;
+import de.zrb.bund.api.ChatStreamListener;
+import okhttp3.*;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.net.Proxy;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public class CloudChatManager implements ChatManager {
+
+    private final Map<UUID, Call> activeCalls = new ConcurrentHashMap<>();
+    private final Map<UUID, ChatHistory> sessionHistories = new ConcurrentHashMap<>();
+
+    private final OkHttpClient baseClient;
+    private final Gson gson;
+
+    public CloudChatManager() {
+        this.baseClient = new OkHttpClient.Builder()
+                .addInterceptor(new RetryInterceptor(7, 1000))
+                .connectTimeout(8, TimeUnit.SECONDS)
+                .readTimeout(0, TimeUnit.MILLISECONDS)
+                .writeTimeout(0, TimeUnit.MILLISECONDS)
+                .build();
+        this.gson = new Gson();
+    }
+
+    @Override
+    public UUID newSession() {
+        UUID sessionId = UUID.randomUUID();
+        sessionHistories.put(sessionId, new ChatHistory(sessionId));
+        return sessionId;
+    }
+
+    @Override
+    public void clearHistory(UUID sessionId) {
+        ChatHistory history = sessionHistories.get(sessionId);
+        if (history != null) {
+            history.clear();
+        }
+    }
+
+    @Override
+    public List<String> getFormattedHistory(UUID sessionId) {
+        ChatHistory history = sessionHistories.get(sessionId);
+        return history != null ? history.getFormattedHistory() : Collections.emptyList();
+    }
+
+    @Override
+    public ChatHistory getHistory(UUID sessionId) {
+        return sessionHistories.getOrDefault(sessionId, new ChatHistory(sessionId));
+    }
+
+    @Override
+    public void addUserMessage(UUID sessionId, String message) {
+        sessionHistories.computeIfAbsent(sessionId, ChatHistory::new).addUserMessage(message);
+    }
+
+    @Override
+    public void addBotMessage(UUID sessionId, String message) {
+        sessionHistories.computeIfAbsent(sessionId, ChatHistory::new).addBotMessage(message);
+    }
+
+    @Override
+    public boolean streamAnswer(UUID sessionId, boolean useContext, String userInput, ChatStreamListener listener, boolean keepAlive) throws IOException {
+        if (sessionId == null || activeCalls.containsKey(sessionId)) {
+            return false;
+        }
+
+        Settings settings = SettingsHelper.load();
+        String url = settings.aiConfig.getOrDefault("cloud.url", "https://api.openai.com/v1/chat/completions");
+        String model = settings.aiConfig.getOrDefault("cloud.model", "gpt-4o-mini");
+        String apiKey = settings.aiConfig.getOrDefault("cloud.apikey", "").trim();
+        String authHeader = settings.aiConfig.getOrDefault("cloud.authHeader", "Authorization").trim();
+        String authPrefix = settings.aiConfig.getOrDefault("cloud.authPrefix", "Bearer").trim();
+
+        if (apiKey.isEmpty()) {
+            listener.onError(new IOException("Cloud API Key fehlt. Bitte in den Einstellungen hinterlegen."));
+            return false;
+        }
+
+        OkHttpClient client = buildClient(url, settings);
+
+        JsonObject payload = new JsonObject();
+        payload.addProperty("model", model);
+        payload.addProperty("stream", true);
+        payload.add("messages", buildMessages(sessionId, useContext, userInput));
+
+        RequestBody requestBody = RequestBody.create(gson.toJson(payload), MediaType.get("application/json"));
+        Request.Builder requestBuilder = new Request.Builder().url(url).post(requestBody);
+
+        String authValue = authPrefix.isEmpty() ? apiKey : authPrefix + " " + apiKey;
+        requestBuilder.header(authHeader.isEmpty() ? "Authorization" : authHeader, authValue.trim());
+
+        String organization = settings.aiConfig.getOrDefault("cloud.organization", "").trim();
+        if (!organization.isEmpty()) {
+            requestBuilder.header("OpenAI-Organization", organization);
+        }
+        String project = settings.aiConfig.getOrDefault("cloud.project", "").trim();
+        if (!project.isEmpty()) {
+            requestBuilder.header("OpenAI-Project", project);
+        }
+
+        Call call = client.newCall(requestBuilder.build());
+        activeCalls.put(sessionId, call);
+        listener.onStreamStart();
+
+        call.enqueue(new Callback() {
+            @Override
+            public void onFailure(Call call, IOException e) {
+                activeCalls.remove(sessionId);
+                listener.onError(e);
+            }
+
+            @Override
+            public void onResponse(Call call, Response response) {
+                try (ResponseBody body = response.body()) {
+                    if (!response.isSuccessful() || body == null) {
+                        listener.onError(new IOException("Unsuccessful response: " + response.code()));
+                        return;
+                    }
+
+                    BufferedReader reader = new BufferedReader(body.charStream());
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        String chunk = extractChunk(line);
+                        if (chunk != null && !chunk.isEmpty()) {
+                            listener.onStreamChunk(chunk);
+                        }
+                    }
+
+                    listener.onStreamEnd();
+                } catch (IOException e) {
+                    listener.onError(e);
+                } finally {
+                    activeCalls.remove(sessionId);
+                }
+            }
+        });
+
+        return true;
+    }
+
+    @Override
+    public void cancel(UUID sessionId) {
+        Call call = activeCalls.remove(sessionId);
+        if (call != null) {
+            call.cancel();
+        }
+    }
+
+    @Override
+    public void onDispose() {
+        // no-op
+    }
+
+    @Override
+    public void closeSession(UUID sessionId) {
+        Call call = activeCalls.remove(sessionId);
+        if (call != null) {
+            call.cancel();
+        }
+        sessionHistories.remove(sessionId);
+    }
+
+    private JsonArray buildMessages(UUID sessionId, boolean useContext, String userInput) {
+        JsonArray messages = new JsonArray();
+        if (useContext) {
+            ChatHistory history = sessionHistories.computeIfAbsent(sessionId, ChatHistory::new);
+            for (ChatHistory.Message message : history.getMessages()) {
+                JsonObject msg = new JsonObject();
+                msg.addProperty("role", message.role);
+                msg.addProperty("content", message.content);
+                messages.add(msg);
+            }
+        }
+
+        JsonObject userMessage = new JsonObject();
+        userMessage.addProperty("role", "user");
+        userMessage.addProperty("content", userInput);
+        messages.add(userMessage);
+        return messages;
+    }
+
+    private String extractChunk(String line) {
+        String trimmed = line == null ? "" : line.trim();
+        if (trimmed.isEmpty()) {
+            return null;
+        }
+        if (trimmed.startsWith("data:")) {
+            trimmed = trimmed.substring("data:".length()).trim();
+        }
+        if ("[DONE]".equals(trimmed)) {
+            return null;
+        }
+
+        try {
+            JsonObject root = JsonParser.parseString(trimmed).getAsJsonObject();
+            if (!root.has("choices") || !root.get("choices").isJsonArray()) {
+                return null;
+            }
+            JsonArray choices = root.getAsJsonArray("choices");
+            if (choices.isEmpty()) {
+                return null;
+            }
+            JsonObject first = choices.get(0).getAsJsonObject();
+
+            if (first.has("delta") && first.get("delta").isJsonObject()) {
+                JsonObject delta = first.getAsJsonObject("delta");
+                if (delta.has("content") && !delta.get("content").isJsonNull()) {
+                    return delta.get("content").getAsString();
+                }
+            }
+
+            if (first.has("message") && first.get("message").isJsonObject()) {
+                JsonObject message = first.getAsJsonObject("message");
+                if (message.has("content") && !message.get("content").isJsonNull()) {
+                    return message.get("content").getAsString();
+                }
+            }
+        } catch (Exception ignored) {
+            return null;
+        }
+
+        return null;
+    }
+
+    private OkHttpClient buildClient(String url, Settings settings) {
+        ProxyResolver.ProxyResolution resolution = ProxyResolver.resolveForUrl(url, settings);
+        return baseClient.newBuilder()
+                .proxy(resolution.isDirect() ? Proxy.NO_PROXY : resolution.getProxy())
+                .build();
+    }
+}

--- a/app/src/main/java/de/bund/zrb/ui/MainFrame.java
+++ b/app/src/main/java/de/bund/zrb/ui/MainFrame.java
@@ -159,6 +159,8 @@ public class MainFrame extends JFrame implements MainframeContext {
         switch (provider) {
             case OLLAMA:
                 return new OllamaChatManager(); // verwendet intern settings.aiConfig
+            case CLOUD:
+                return new CloudChatManager();
             case LOCAL_AI:
                 return new LocalAiChatManager(); // analog auf settings.aiConfig zugreifen
             case LLAMA_CPP_SERVER:

--- a/app/src/main/java/de/bund/zrb/ui/settings/SettingsDialog.java
+++ b/app/src/main/java/de/bund/zrb/ui/settings/SettingsDialog.java
@@ -51,6 +51,14 @@ public class SettingsDialog {
     private static JTextField ollamaUrlField;
     private static JTextField ollamaModelField;
     private static JTextField ollamaKeepAliveField;
+    private static JComboBox<String> cloudProviderField;
+    private static JTextField cloudApiKeyField;
+    private static JTextField cloudApiUrlField;
+    private static JTextField cloudModelField;
+    private static JTextField cloudAuthHeaderField;
+    private static JTextField cloudAuthPrefixField;
+    private static JTextField cloudOrgField;
+    private static JTextField cloudProjectField;
     private static JCheckBox wrapJsonBox;
     private static JCheckBox prettyJsonBox;
     private static JTextField defaultWorkflow;
@@ -554,10 +562,12 @@ public class SettingsDialog {
         // Panels für Provider
         JPanel disabledPanel = new JPanel();
         JPanel ollamaPanel = new JPanel(new GridBagLayout());
+        JPanel cloudPanel = new JPanel(new GridBagLayout());
         JPanel localAiPanel = new JPanel(new GridBagLayout());
 
         providerOptionsPanel.add(disabledPanel, AiProvider.DISABLED.name());
         providerOptionsPanel.add(ollamaPanel, AiProvider.OLLAMA.name());
+        providerOptionsPanel.add(cloudPanel, AiProvider.CLOUD.name());
         providerOptionsPanel.add(localAiPanel, AiProvider.LOCAL_AI.name());
 
         // OLLAMA-Felder
@@ -577,6 +587,60 @@ public class SettingsDialog {
         ollamaKeepAliveField = new JTextField(20);
         ollamaPanel.add(ollamaKeepAliveField, gbcOllama);
         gbcOllama.gridy++;
+
+        // CLOUD-Felder
+        GridBagConstraints gbcCloud = createDefaultGbc();
+        cloudPanel.add(new JLabel("Cloud-Anbieter:"), gbcCloud);
+        gbcCloud.gridy++;
+        cloudProviderField = new JComboBox<>(new String[]{"OPENAI", "CLOUD", "PERPLEXITY", "GROK", "GEMINI"});
+        cloudPanel.add(cloudProviderField, gbcCloud);
+        gbcCloud.gridy++;
+
+        cloudPanel.add(new JLabel("API Key:"), gbcCloud);
+        gbcCloud.gridy++;
+        cloudApiKeyField = new JTextField(30);
+        cloudPanel.add(cloudApiKeyField, gbcCloud);
+        gbcCloud.gridy++;
+
+        cloudPanel.add(new JLabel("API URL:"), gbcCloud);
+        gbcCloud.gridy++;
+        cloudApiUrlField = new JTextField(30);
+        cloudPanel.add(cloudApiUrlField, gbcCloud);
+        gbcCloud.gridy++;
+
+        cloudPanel.add(new JLabel("Modell:"), gbcCloud);
+        gbcCloud.gridy++;
+        cloudModelField = new JTextField(30);
+        cloudPanel.add(cloudModelField, gbcCloud);
+        gbcCloud.gridy++;
+
+        cloudPanel.add(new JLabel("Auth Header:"), gbcCloud);
+        gbcCloud.gridy++;
+        cloudAuthHeaderField = new JTextField(30);
+        cloudPanel.add(cloudAuthHeaderField, gbcCloud);
+        gbcCloud.gridy++;
+
+        cloudPanel.add(new JLabel("Auth Prefix (z. B. Bearer):"), gbcCloud);
+        gbcCloud.gridy++;
+        cloudAuthPrefixField = new JTextField(30);
+        cloudPanel.add(cloudAuthPrefixField, gbcCloud);
+        gbcCloud.gridy++;
+
+        cloudPanel.add(new JLabel("OpenAI Organisation (optional):"), gbcCloud);
+        gbcCloud.gridy++;
+        cloudOrgField = new JTextField(30);
+        cloudPanel.add(cloudOrgField, gbcCloud);
+        gbcCloud.gridy++;
+
+        cloudPanel.add(new JLabel("OpenAI Projekt (optional):"), gbcCloud);
+        gbcCloud.gridy++;
+        cloudProjectField = new JTextField(30);
+        cloudPanel.add(cloudProjectField, gbcCloud);
+        gbcCloud.gridy++;
+
+        JButton cloudResetButton = new JButton("Defaults zurücksetzen");
+        cloudPanel.add(cloudResetButton, gbcCloud);
+        gbcCloud.gridy++;
 
         ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -712,6 +776,28 @@ public class SettingsDialog {
         ollamaModelField.setText(settings.aiConfig.getOrDefault("ollama.model", "custom-modell"));
         ollamaKeepAliveField.setText(settings.aiConfig.getOrDefault("ollama.keepalive", "10m"));
 
+        String initialCloudVendor = settings.aiConfig.getOrDefault("cloud.vendor", "OPENAI");
+        cloudProviderField.setSelectedItem(initialCloudVendor);
+        applyCloudVendorDefaults(false);
+        cloudApiKeyField.setText(settings.aiConfig.getOrDefault("cloud.apikey", ""));
+        cloudApiUrlField.setText(settings.aiConfig.getOrDefault("cloud.url", cloudDefaultForVendor(initialCloudVendor, "url")));
+        cloudModelField.setText(settings.aiConfig.getOrDefault("cloud.model", cloudDefaultForVendor(initialCloudVendor, "model")));
+        cloudAuthHeaderField.setText(settings.aiConfig.getOrDefault("cloud.authHeader", cloudDefaultForVendor(initialCloudVendor, "authHeader")));
+        cloudAuthPrefixField.setText(settings.aiConfig.getOrDefault("cloud.authPrefix", cloudDefaultForVendor(initialCloudVendor, "authPrefix")));
+        cloudOrgField.setText(settings.aiConfig.getOrDefault("cloud.organization", ""));
+        cloudProjectField.setText(settings.aiConfig.getOrDefault("cloud.project", ""));
+
+        cloudProviderField.addActionListener(e -> applyCloudVendorDefaults(true));
+        cloudResetButton.addActionListener(e -> {
+            String selectedVendor = (String) cloudProviderField.getSelectedItem();
+            applyCloudVendorDefaults(true);
+            cloudApiKeyField.setText("");
+            if (!"OPENAI".equals(selectedVendor)) {
+                cloudOrgField.setText("");
+                cloudProjectField.setText("");
+            }
+        });
+
         // Umschalten je nach Provider
         providerCombo.addActionListener(e -> {
             AiProvider selected = (AiProvider) providerCombo.getSelectedItem();
@@ -720,6 +806,52 @@ public class SettingsDialog {
         });
 
         ((CardLayout) providerOptionsPanel.getLayout()).show(providerOptionsPanel, selectedProvider.name());
+    }
+
+    private static void applyCloudVendorDefaults(boolean clearOptionalFields) {
+        String vendor = Objects.toString(cloudProviderField.getSelectedItem(), "OPENAI");
+        cloudApiUrlField.setText(cloudDefaultForVendor(vendor, "url"));
+        cloudModelField.setText(cloudDefaultForVendor(vendor, "model"));
+        cloudAuthHeaderField.setText(cloudDefaultForVendor(vendor, "authHeader"));
+        cloudAuthPrefixField.setText(cloudDefaultForVendor(vendor, "authPrefix"));
+
+        boolean isOpenAi = "OPENAI".equals(vendor);
+        cloudOrgField.setEnabled(isOpenAi);
+        cloudProjectField.setEnabled(isOpenAi);
+        if (clearOptionalFields && !isOpenAi) {
+            cloudOrgField.setText("");
+            cloudProjectField.setText("");
+        }
+    }
+
+    private static String cloudDefaultForVendor(String vendor, String key) {
+        switch (vendor) {
+            case "PERPLEXITY":
+                if ("url".equals(key)) return "https://api.perplexity.ai/chat/completions";
+                if ("model".equals(key)) return "sonar";
+                break;
+            case "GROK":
+                if ("url".equals(key)) return "https://api.x.ai/v1/chat/completions";
+                if ("model".equals(key)) return "grok-2-latest";
+                break;
+            case "GEMINI":
+                if ("url".equals(key)) return "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+                if ("model".equals(key)) return "gemini-2.0-flash";
+                break;
+            case "CLOUD":
+                if ("url".equals(key)) return "https://api.openai.com/v1/chat/completions";
+                if ("model".equals(key)) return "gpt-4o-mini";
+                break;
+            case "OPENAI":
+            default:
+                if ("url".equals(key)) return "https://api.openai.com/v1/chat/completions";
+                if ("model".equals(key)) return "gpt-4o-mini";
+                break;
+        }
+
+        if ("authHeader".equals(key)) return "Authorization";
+        if ("authPrefix".equals(key)) return "Bearer";
+        return "";
     }
 
     private static void createProxyContent(JPanel proxyContent, Component parent) {
@@ -876,6 +1008,14 @@ public class SettingsDialog {
             settings.aiConfig.put("ollama.url", ollamaUrlField.getText().trim());
             settings.aiConfig.put("ollama.model", ollamaModelField.getText().trim());
             settings.aiConfig.put("ollama.keepalive", ollamaKeepAliveField.getText().trim());
+            settings.aiConfig.put("cloud.vendor", Objects.toString(cloudProviderField.getSelectedItem(), "OPENAI"));
+            settings.aiConfig.put("cloud.apikey", cloudApiKeyField.getText().trim());
+            settings.aiConfig.put("cloud.url", cloudApiUrlField.getText().trim());
+            settings.aiConfig.put("cloud.model", cloudModelField.getText().trim());
+            settings.aiConfig.put("cloud.authHeader", cloudAuthHeaderField.getText().trim());
+            settings.aiConfig.put("cloud.authPrefix", cloudAuthPrefixField.getText().trim());
+            settings.aiConfig.put("cloud.organization", cloudOrgField.getText().trim());
+            settings.aiConfig.put("cloud.project", cloudProjectField.getText().trim());
             settings.aiConfig.put("llama.enabled", String.valueOf(llamaEnabledBox.isSelected()));
             settings.aiConfig.put("llama.binary", llamaBinaryField.getText().trim());
             settings.aiConfig.put("llama.model", llamaModelField.getText().trim());


### PR DESCRIPTION
### Motivation
- Provide a new configurable "Cloud" AI provider based on the existing Ollama workflow so users can select mainstream hosted vendors (OpenAI, Perplexity, Grok, Gemini, etc.) and only enter an API key while other values are prefilled.
- Keep behavior and configuration consistent with existing providers (Ollama / llama.cpp) including proxy resolution and streaming support.

### Description
- Add a new enum value `AiProvider.CLOUD` and instantiate `CloudChatManager` in `MainFrame#getAiService()` to enable runtime selection. (`app/src/main/java/de/bund/zrb/model/AiProvider.java`, `app/src/main/java/de/bund/zrb/ui/MainFrame.java`).
- Implement `CloudChatManager` that mirrors Ollama-style streaming and reads configuration from `settings.aiConfig`; it sends OpenAI-compatible chat/completions requests, handles SSE and non-stream chunks (`choices[].delta.content` and `choices[].message.content`), supports configurable auth header/prefix and optional OpenAI org/project headers, and uses `ProxyResolver` like other managers. (`app/src/main/java/de/bund/zrb/service/CloudChatManager.java`).
- Extend settings UI to add a `CLOUD` card with a vendor dropdown (`OPENAI`, `CLOUD`, `PERPLEXITY`, `GROK`, `GEMINI`), API key input, prefilled `url`, `model`, `authHeader`, `authPrefix` defaults per vendor, optional OpenAI `organization` and `project` fields enabled for `OPENAI`, and a reset button that restores defaults and clears sensitive fields; persist all cloud config keys into `settings.aiConfig`. (`app/src/main/java/de/bund/zrb/ui/settings/SettingsDialog.java`).

### Testing
- Attempted to compile with `bash ./gradlew :app:compileJava`, but the Gradle wrapper download failed due to a network/proxy restriction (`HTTP/1.1 403 Forbidden`), so a local build could not be completed. This prevented running automated Java compilation tests.
- Verified repository changes and commit via `git status` and `git show` and committed the changes (`Add configurable Cloud AI provider based on Ollama workflow`), which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995f112edcc8333bda4669801e0389f)