### PR TITLE
Mode-aware tool policies, approval flow and per-mode tool contracts

### DIFF
--- a/app/src/main/java/de/bund/zrb/tools/ToolAccessType.java
+++ b/app/src/main/java/de/bund/zrb/tools/ToolAccessType.java
@@ -1,0 +1,11 @@
+package de.bund.zrb.tools;
+
+/** Access class for tools. */
+public enum ToolAccessType {
+    READ,
+    WRITE;
+
+    public boolean isWrite() {
+        return this == WRITE;
+    }
+}

--- a/app/src/main/java/de/bund/zrb/tools/ToolAccessTypeDefaults.java
+++ b/app/src/main/java/de/bund/zrb/tools/ToolAccessTypeDefaults.java
@@ -1,0 +1,20 @@
+package de.bund.zrb.tools;
+
+/** Derive fallback access type for tools without explicit policy. */
+public final class ToolAccessTypeDefaults {
+
+    private ToolAccessTypeDefaults() {
+    }
+
+    public static ToolAccessType resolveDefault(String toolName) {
+        if (toolName == null) {
+            return ToolAccessType.READ;
+        }
+        String n = toolName.toLowerCase();
+        if (n.contains("write") || n.contains("set") || n.contains("save") || n.contains("delete")
+                || n.contains("update") || n.contains("create") || n.contains("import") || n.contains("open")) {
+            return ToolAccessType.WRITE;
+        }
+        return ToolAccessType.READ;
+    }
+}

--- a/app/src/main/java/de/bund/zrb/tools/ToolPolicy.java
+++ b/app/src/main/java/de/bund/zrb/tools/ToolPolicy.java
@@ -1,0 +1,53 @@
+package de.bund.zrb.tools;
+
+/** Persisted user policy for a tool. */
+public class ToolPolicy {
+
+    private String toolName;
+    private boolean enabled;
+    private boolean askBeforeUse;
+    private ToolAccessType accessType;
+
+    public ToolPolicy() {
+        // for JSON
+    }
+
+    public ToolPolicy(String toolName, boolean enabled, boolean askBeforeUse, ToolAccessType accessType) {
+        this.toolName = toolName;
+        this.enabled = enabled;
+        this.askBeforeUse = askBeforeUse;
+        this.accessType = accessType;
+    }
+
+    public String getToolName() {
+        return toolName;
+    }
+
+    public void setToolName(String toolName) {
+        this.toolName = toolName;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public boolean isAskBeforeUse() {
+        return askBeforeUse;
+    }
+
+    public void setAskBeforeUse(boolean askBeforeUse) {
+        this.askBeforeUse = askBeforeUse;
+    }
+
+    public ToolAccessType getAccessType() {
+        return accessType;
+    }
+
+    public void setAccessType(ToolAccessType accessType) {
+        this.accessType = accessType;
+    }
+}

--- a/app/src/main/java/de/bund/zrb/tools/ToolPolicyRepository.java
+++ b/app/src/main/java/de/bund/zrb/tools/ToolPolicyRepository.java
@@ -1,0 +1,89 @@
+package de.bund.zrb.tools;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import de.bund.zrb.helper.SettingsHelper;
+import de.bund.zrb.runtime.ToolRegistryImpl;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.Reader;
+import java.io.Writer;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Store tool policies in settings folder. */
+public class ToolPolicyRepository {
+
+    private static final File FILE = new File(SettingsHelper.getSettingsFolder(), "tool-policies.json");
+    private static final Type LIST_TYPE = new TypeToken<List<ToolPolicy>>() { }.getType();
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    public List<ToolPolicy> loadAll() {
+        List<ToolPolicy> existing = readFile();
+        Map<String, ToolPolicy> merged = new LinkedHashMap<>();
+        for (ToolPolicy p : existing) {
+            if (p != null && p.getToolName() != null) {
+                if (p.getAccessType() == null) {
+                    p.setAccessType(ToolAccessTypeDefaults.resolveDefault(p.getToolName()));
+                }
+                merged.put(p.getToolName(), p);
+            }
+        }
+
+        ToolRegistryImpl.getInstance().getAllTools().forEach(tool -> {
+            String name = tool.getSpec().getName();
+            if (!merged.containsKey(name)) {
+                ToolAccessType access = ToolAccessTypeDefaults.resolveDefault(name);
+                boolean ask = access.isWrite();
+                merged.put(name, new ToolPolicy(name, true, ask, access));
+            }
+        });
+
+        List<ToolPolicy> list = new ArrayList<>(merged.values());
+        saveAll(list);
+        return list;
+    }
+
+    public ToolPolicy findByToolName(String toolName) {
+        if (toolName == null) {
+            return null;
+        }
+        return loadAll().stream()
+                .filter(p -> toolName.equalsIgnoreCase(p.getToolName()))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public void saveAll(List<ToolPolicy> policies) {
+        try {
+            FILE.getParentFile().mkdirs();
+            try (Writer w = new OutputStreamWriter(new FileOutputStream(FILE), StandardCharsets.UTF_8)) {
+                GSON.toJson(policies, LIST_TYPE, w);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private List<ToolPolicy> readFile() {
+        if (!FILE.exists()) {
+            return new ArrayList<>();
+        }
+        try (Reader r = new InputStreamReader(new FileInputStream(FILE), StandardCharsets.UTF_8)) {
+            List<ToolPolicy> policies = GSON.fromJson(r, LIST_TYPE);
+            return policies == null ? new ArrayList<>() : policies;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return new ArrayList<>();
+        }
+    }
+}

--- a/app/src/main/java/de/bund/zrb/ui/components/ChatMode.java
+++ b/app/src/main/java/de/bund/zrb/ui/components/ChatMode.java
@@ -1,79 +1,80 @@
 package de.bund.zrb.ui.components;
 
-/**
- * Chat modes similar to GitHub Copilot: control how the assistant behaves.
- */
+import de.bund.zrb.tools.ToolAccessType;
+
+import java.util.EnumSet;
+
+/** Chat modes similar to GitHub Copilot: control how the assistant behaves. */
 public enum ChatMode {
 
-    /**
-     * Default Q&A mode. Short, direct Antworten, Tools nur punktuell.
-     */
     ASK(
             "Ask",
-            "Stellt Fragen und bekommt direkte Antworten. Kurze, präzise Erklärungen, Tools nur bei Bedarf.",
+            "Stellt Fragen und bekommt direkte Antworten. Tools nur bei Bedarf.",
             "Du bist ein hilfreicher Assistent in einer Mainframe- und Dateibrowser-Anwendung. " +
-                    "Antworte kurz und präzise. Nutze Tools nur, wenn der Nutzer dich explizit " +
-                    "nach Dateien, Inhalten oder konkreten Aktionen fragt. Wenn du Tools nutzt, " +
-                    "halte die Anzahl der Tool-Aufrufe gering und erkläre das Ergebnis verständlich."
+                    "Antworte kurz und präzise. Wenn der Nutzer nach Dateien, Inhalten oder Aktionen fragt, " +
+                    "kannst du Tools verwenden, aber bleibe sparsam.",
+            false,
+            EnumSet.noneOf(ToolAccessType.class),
+            "",
+            ""
     ),
 
-    /**
-     * Edit mode: Fokus auf Änderungen an bestehendem Code/Text.
-     */
     EDIT(
             "Edit",
-            "Hilft beim Ändern von bestehendem Text/Code. Fokus auf Diff-artige Vorschläge.",
-            "Du bist ein Assistent für Text- und Code-Änderungen. Der Nutzer zeigt dir bestehenden Inhalt " +
-                    "(z.B. aus dem Editor) und beschreibt Änderungswünsche. Antworte mit konkreten, " +
-                    "lokal begrenzten Änderungsvorschlägen. Wenn sinnvoll, zitiere nur die relevanten " +
-                    "Ausschnitte statt alles zu wiederholen. Nutze Tools, um Dateien zu lesen, wenn dir " +
-                    "Kontext fehlt."
+            "Hilft beim Ändern von bestehendem Text/Code.",
+            "Du bist ein Assistent für Text- und Code-Änderungen. Liefere konkrete, lokal begrenzte Vorschläge. " +
+                    "Nutze Tools, um Kontext zu lesen, wenn er fehlt. Schreibende Tools nur, wenn der Nutzer es explizit will.",
+            true,
+            EnumSet.of(ToolAccessType.READ, ToolAccessType.WRITE),
+            defaultToolPrefix(),
+            ""
     ),
 
-    /**
-     * Plan mode: erstellt mehrstufige Pläne, keine großen Änderungen direkt.
-     */
     PLAN(
             "Plan",
             "Erstellt mehrstufige Umsetzungspläne, bevor etwas geändert wird.",
-            "Du bist ein Planungs-Assistent. Deine Hauptaufgabe ist es, mehrstufige, realistische " +
-                    "Pläne zu entwerfen (z.B. für Refactorings, Features oder Analysen). Bevor du " +
-                    "Konkreten Code vorschlägst, skizziere immer zuerst einen Plan mit nummerierten " +
-                    "Schritten. Nutze Tools, um Codebasis und Dateien zu inspizieren, bevor du den Plan " +
-                    "finalisierst. Führe selbst keine großen Änderungen aus – liefere primär den Plan."
+            "Du bist ein Planungs-Assistent. Skizziere immer zuerst einen Plan mit nummerierten Schritten. " +
+                    "Nutze Tools, um die Codebasis zu inspizieren, bevor du den Plan finalisierst. " +
+                    "Führe selbst keine großen Änderungen aus – liefere primär den Plan.",
+            true,
+            EnumSet.of(ToolAccessType.READ),
+            defaultToolPrefix(),
+            ""
     ),
 
-    /**
-     * Agent mode: darf Tools iterativ und autonom nutzen, bis das Ziel erreicht ist.
-     */
     AGENT(
             "Agent",
             "Handelt wie ein Agent: nutzt Tools iterativ, bis die Aufgabe erledigt ist.",
-            "Du bist ein hilfreicher Assistent in einer Editor-Anwendung mit Zugriff auf Tools:\n" +
-                    "- 'read_file': Liest Dateiinhalt oder listet ein Verzeichnis (ohne Tab zu öffnen).\n" +
-                    "- 'open_file': Öffnet eine Datei oder ein Verzeichnis als Tab.\n\n" +
-                    "WANN du Tools nutzt:\n" +
-                    "- NUR wenn der Nutzer explizit nach Dateien, Verzeichnissen, Inhalten oder Aktionen fragt.\n" +
-                    "- Bei Smalltalk, Fragen, Erklärungen oder allgemeinen Gesprächen: KEINE Tools nutzen, " +
-                    "einfach normal antworten.\n\n" +
-                    "WIE du Tools nutzt (wenn nötig):\n" +
-                    "1. Erst das Verzeichnis listen (read_file mit Verzeichnispfad), um zu sehen was da ist.\n" +
-                    "2. Dann gezielt nur die relevanten Dateien lesen – NICHT alle Dateien blind öffnen.\n" +
-                    "3. Erzeuge pro Schritt EINEN Tool-Call als JSON: {\"name\":\"read_file\",\"input\":{\"path\":\"...\"}}\n" +
-                    "4. Wenn du die gesuchte Information gefunden hast, STOPPE und antworte dem Nutzer.\n" +
-                    "5. Lies eine Datei NIEMALS zweimal. Merke dir, was du bereits gelesen hast.\n" +
-                    "6. Bei Fehlern: analysiere die Meldung und versuche einen korrigierten Aufruf.\n\n" +
-                    "WICHTIG: Wenn die Aufgabe keine Dateioperationen erfordert, antworte direkt OHNE Tool-Call."
+            "Du bist ein hilfreicher Agent in einer Editor-Anwendung. Nutze Tools iterativ, aber nur wenn nötig. " +
+                    "Arbeite schrittweise, pro Schritt genau EINEN Tool-Call. Wenn genug Informationen da sind: STOPP und antworte.",
+            true,
+            EnumSet.of(ToolAccessType.READ, ToolAccessType.WRITE),
+            defaultToolPrefix(),
+            ""
     );
 
     private final String label;
     private final String tooltip;
     private final String systemPrompt;
+    private final boolean toolAware;
+    private final EnumSet<ToolAccessType> allowedToolAccess;
+    private final String defaultToolPrefix;
+    private final String defaultToolPostfix;
 
-    ChatMode(String label, String tooltip, String systemPrompt) {
+    ChatMode(String label,
+             String tooltip,
+             String systemPrompt,
+             boolean toolAware,
+             EnumSet<ToolAccessType> allowedToolAccess,
+             String defaultToolPrefix,
+             String defaultToolPostfix) {
         this.label = label;
         this.tooltip = tooltip;
         this.systemPrompt = systemPrompt;
+        this.toolAware = toolAware;
+        this.allowedToolAccess = allowedToolAccess;
+        this.defaultToolPrefix = defaultToolPrefix;
+        this.defaultToolPostfix = defaultToolPostfix;
     }
 
     public String getLabel() {
@@ -88,9 +89,29 @@ public enum ChatMode {
         return systemPrompt;
     }
 
+    public boolean isToolAware() {
+        return toolAware;
+    }
+
+    public EnumSet<ToolAccessType> getAllowedToolAccess() {
+        return allowedToolAccess;
+    }
+
+    public String getDefaultToolPrefix() {
+        return defaultToolPrefix;
+    }
+
+    public String getDefaultToolPostfix() {
+        return defaultToolPostfix;
+    }
+
+    private static String defaultToolPrefix() {
+        return "Wenn du ein Tool benutzen willst, antworte NUR mit dem JSON-Tool-Call (kein weiterer Text). " +
+                "Format: {\"name\":\"tool_name\",\"input\":{...}}. Wenn du kein Tool brauchst, antworte normal.";
+    }
+
     @Override
     public String toString() {
         return label;
     }
 }
-

--- a/app/src/main/java/de/bund/zrb/ui/settings/ToolPolicyDialog.java
+++ b/app/src/main/java/de/bund/zrb/ui/settings/ToolPolicyDialog.java
@@ -1,0 +1,201 @@
+package de.bund.zrb.ui.settings;
+
+import de.bund.zrb.runtime.ToolRegistryImpl;
+import de.bund.zrb.tools.ToolAccessType;
+import de.bund.zrb.tools.ToolPolicy;
+import de.bund.zrb.tools.ToolPolicyRepository;
+import de.zrb.bund.newApi.mcp.McpTool;
+
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.RowFilter;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.table.TableRowSorter;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Manage enabled/approval/access policies for tools. */
+public class ToolPolicyDialog {
+
+    public static void show(Component parent) {
+        ToolPolicyRepository repository = new ToolPolicyRepository();
+        List<ToolPolicy> policies = new ArrayList<>(repository.loadAll());
+        Map<String, ToolPolicy> byName = new HashMap<>();
+        for (ToolPolicy p : policies) {
+            byName.put(p.getToolName(), p);
+        }
+
+        List<Row> rows = new ArrayList<>();
+        for (McpTool tool : ToolRegistryImpl.getInstance().getAllTools()) {
+            String name = tool.getSpec().getName();
+            ToolPolicy policy = byName.get(name);
+            if (policy == null) {
+                continue;
+            }
+            rows.add(new Row(policy, tool.getSpec().getDescription()));
+        }
+
+        Model model = new Model(rows);
+        JTable table = new JTable(model);
+        table.getColumnModel().getColumn(0).setPreferredWidth(80);
+        table.getColumnModel().getColumn(1).setPreferredWidth(80);
+        table.getColumnModel().getColumn(2).setPreferredWidth(80);
+        table.getColumnModel().getColumn(3).setPreferredWidth(180);
+        table.getColumnModel().getColumn(4).setPreferredWidth(380);
+
+        JComboBox<ToolAccessType> accessEditor = new JComboBox<>(ToolAccessType.values());
+        table.getColumnModel().getColumn(2).setCellEditor(new javax.swing.DefaultCellEditor(accessEditor));
+
+        TableRowSorter<Model> sorter = new TableRowSorter<>(model);
+        table.setRowSorter(sorter);
+
+        JTextField filterField = new JTextField(24);
+        filterField.getDocument().addDocumentListener(new javax.swing.event.DocumentListener() {
+            @Override
+            public void insertUpdate(javax.swing.event.DocumentEvent e) { apply(); }
+            @Override
+            public void removeUpdate(javax.swing.event.DocumentEvent e) { apply(); }
+            @Override
+            public void changedUpdate(javax.swing.event.DocumentEvent e) { apply(); }
+            private void apply() {
+                String text = filterField.getText();
+                if (text == null || text.trim().isEmpty()) {
+                    sorter.setRowFilter(null);
+                    return;
+                }
+                sorter.setRowFilter(RowFilter.regexFilter("(?i)" + java.util.regex.Pattern.quote(text.trim()), 3, 4));
+            }
+        });
+
+        JPanel searchPanel = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        searchPanel.add(new JLabel("Suche:"));
+        searchPanel.add(filterField);
+
+        JPanel center = new JPanel(new BorderLayout(4, 4));
+        center.add(searchPanel, BorderLayout.NORTH);
+        center.add(new JScrollPane(table), BorderLayout.CENTER);
+
+        JDialog dialog = new JDialog((Frame) null, "Tool-Konfiguration", true);
+        dialog.setLayout(new BorderLayout(4, 4));
+        dialog.add(center, BorderLayout.CENTER);
+
+        JPanel buttons = new JPanel(new FlowLayout(FlowLayout.RIGHT));
+        javax.swing.JButton cancel = new javax.swing.JButton("Abbrechen");
+        javax.swing.JButton ok = new javax.swing.JButton("Speichern");
+        buttons.add(cancel);
+        buttons.add(ok);
+        dialog.add(buttons, BorderLayout.SOUTH);
+
+        cancel.addActionListener(e -> dialog.dispose());
+        ok.addActionListener(e -> {
+            repository.saveAll(model.toPolicies());
+            dialog.dispose();
+        });
+
+        dialog.setSize(920, 460);
+        dialog.setLocationRelativeTo(parent);
+        dialog.setVisible(true);
+    }
+
+    private static class Row {
+        private final ToolPolicy policy;
+        private final String description;
+
+        private Row(ToolPolicy policy, String description) {
+            this.policy = policy;
+            this.description = description;
+        }
+    }
+
+    private static class Model extends AbstractTableModel {
+        private final String[] columns = {"Aktiv", "Nachfragen", "Typ", "Tool", "Beschreibung"};
+        private final List<Row> rows;
+
+        private Model(List<Row> rows) {
+            this.rows = rows;
+        }
+
+        @Override
+        public int getRowCount() {
+            return rows.size();
+        }
+
+        @Override
+        public int getColumnCount() {
+            return columns.length;
+        }
+
+        @Override
+        public String getColumnName(int column) {
+            return columns[column];
+        }
+
+        @Override
+        public Class<?> getColumnClass(int columnIndex) {
+            if (columnIndex == 0 || columnIndex == 1) {
+                return Boolean.class;
+            }
+            if (columnIndex == 2) {
+                return ToolAccessType.class;
+            }
+            return String.class;
+        }
+
+        @Override
+        public boolean isCellEditable(int rowIndex, int columnIndex) {
+            return columnIndex <= 2;
+        }
+
+        @Override
+        public Object getValueAt(int rowIndex, int columnIndex) {
+            Row row = rows.get(rowIndex);
+            if (columnIndex == 0) {
+                return row.policy.isEnabled();
+            }
+            if (columnIndex == 1) {
+                return row.policy.isAskBeforeUse();
+            }
+            if (columnIndex == 2) {
+                return row.policy.getAccessType();
+            }
+            if (columnIndex == 3) {
+                return row.policy.getToolName();
+            }
+            return Objects.toString(row.description, "");
+        }
+
+        @Override
+        public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
+            Row row = rows.get(rowIndex);
+            if (columnIndex == 0) {
+                row.policy.setEnabled(Boolean.TRUE.equals(aValue));
+            } else if (columnIndex == 1) {
+                row.policy.setAskBeforeUse(Boolean.TRUE.equals(aValue));
+            } else if (columnIndex == 2 && aValue instanceof ToolAccessType) {
+                row.policy.setAccessType((ToolAccessType) aValue);
+            }
+            fireTableRowsUpdated(rowIndex, rowIndex);
+        }
+
+        public List<ToolPolicy> toPolicies() {
+            List<ToolPolicy> out = new ArrayList<>();
+            for (Row row : rows) {
+                out.add(row.policy);
+            }
+            return out;
+        }
+    }
+}

--- a/app/src/main/java/de/bund/zrb/ui/util/ChatFormatter.java
+++ b/app/src/main/java/de/bund/zrb/ui/util/ChatFormatter.java
@@ -180,6 +180,77 @@ public class ChatFormatter {
         scrollToBottom();
     }
 
+    public ToolApprovalRequest requestToolApproval(String toolName, String toolCallJson, boolean isWrite) {
+        ToolApprovalRequest request = new ToolApprovalRequest();
+        JPanel wrapper = createMessagePanelWrapper(Role.TOOL);
+
+        JPanel header = new JPanel();
+        header.setLayout(new BoxLayout(header, BoxLayout.X_AXIS));
+        header.setAlignmentX(Component.LEFT_ALIGNMENT);
+        header.setOpaque(false);
+
+        String title = "🔒 Freigabe: " + (toolName == null ? "" : toolName) + (isWrite ? " (WRITE)" : " (READ)");
+        JLabel titleLabel = new JLabel(title);
+        titleLabel.setFont(titleLabel.getFont().deriveFont(Font.BOLD, 12f));
+        header.add(titleLabel);
+        header.add(Box.createHorizontalGlue());
+
+        JButton detailsButton = new JButton("Details");
+        detailsButton.setFocusable(false);
+        header.add(detailsButton);
+
+        JButton approveButton = new JButton("Ausführen");
+        approveButton.setFocusable(false);
+        header.add(Box.createHorizontalStrut(6));
+        header.add(approveButton);
+
+        JButton cancelButton = new JButton("Abbrechen");
+        cancelButton.setFocusable(false);
+        header.add(Box.createHorizontalStrut(4));
+        header.add(cancelButton);
+
+        JTextPane bodyPane = createConfiguredTextPane();
+        String html = ChatMarkdownFormatter.format("```json\n" + (toolCallJson == null ? "" : toolCallJson) + "\n```");
+        bodyPane.setText(formatHtml(html));
+        bodyPane.setVisible(false);
+
+        detailsButton.addActionListener(e -> {
+            bodyPane.setVisible(!bodyPane.isVisible());
+            applyDynamicSizing(bodyPane);
+            wrapper.revalidate();
+            wrapper.repaint();
+            scrollToBottom();
+        });
+
+        java.util.concurrent.atomic.AtomicBoolean decided = new java.util.concurrent.atomic.AtomicBoolean(false);
+        approveButton.addActionListener(e -> {
+            if (decided.compareAndSet(false, true)) {
+                approveButton.setEnabled(false);
+                cancelButton.setEnabled(false);
+                titleLabel.setText(title + " ✅");
+                request.approve();
+            }
+        });
+
+        cancelButton.addActionListener(e -> {
+            if (decided.compareAndSet(false, true)) {
+                approveButton.setEnabled(false);
+                cancelButton.setEnabled(false);
+                titleLabel.setText(title + " ❌");
+                request.cancel();
+            }
+        });
+
+        wrapper.add(header);
+        wrapper.add(Box.createVerticalStrut(4));
+        wrapper.add(bodyPane);
+
+        messageContainer.add(wrapper);
+        messageContainer.add(Box.createVerticalStrut(6));
+        scrollToBottom();
+        return request;
+    }
+
     private JTextPane createConfiguredTextPane() {
         JTextPane pane = new JTextPane();
         pane.setName("contentPane");

--- a/app/src/main/java/de/bund/zrb/ui/util/ToolApprovalDecision.java
+++ b/app/src/main/java/de/bund/zrb/ui/util/ToolApprovalDecision.java
@@ -1,0 +1,6 @@
+package de.bund.zrb.ui.util;
+
+public enum ToolApprovalDecision {
+    APPROVED,
+    CANCELLED
+}

--- a/app/src/main/java/de/bund/zrb/ui/util/ToolApprovalRequest.java
+++ b/app/src/main/java/de/bund/zrb/ui/util/ToolApprovalRequest.java
@@ -1,0 +1,29 @@
+package de.bund.zrb.ui.util;
+
+import java.util.concurrent.CountDownLatch;
+
+/** Wait holder for async approval UI. */
+public class ToolApprovalRequest {
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+    private volatile ToolApprovalDecision decision = ToolApprovalDecision.CANCELLED;
+
+    public void approve() {
+        decision = ToolApprovalDecision.APPROVED;
+        latch.countDown();
+    }
+
+    public void cancel() {
+        decision = ToolApprovalDecision.CANCELLED;
+        latch.countDown();
+    }
+
+    public ToolApprovalDecision awaitDecision() {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return decision;
+    }
+}


### PR DESCRIPTION
### Motivation
- Replace the old dropdown-based injection of tool JSON into user prompts with a safer, mode-driven contract and policy layer to avoid collisions with Agent/Plan/Edit workflows.
- Ensure each tool is classified with explicit access semantics (READ/WRITE), persisted user policies (enabled/askBeforeUse) and an approval flow for potentially destructive actions.
- Provide on-demand tool details (like ChatGPT’s tool description) instead of exposing full schemas by default, and let users configure per-mode tool-call instructions (prefix/postfix).

### Description
- Introduced a policy model and repository: `ToolAccessType`, `ToolPolicy`, `ToolAccessTypeDefaults`, and `ToolPolicyRepository` to persist per-tool `enabled`/`askBeforeUse`/accessType and merge with registered tools.
- Reworked chat modes (`ChatMode`) to carry tool-awareness, allowed access types and default contract text, and added system-prompt composition in `ChatSession` to inject per-mode `toolPrefix.<MODE>` / `toolPostfix.<MODE>` and a coarse enabled-tool summary.
- Removed the per-message tool dropdown injection and added a chat toolbar button (`🛠`) opening `ToolPolicyDialog` so the user can enable/disable tools, set ASK and choose READ/WRITE for each tool.
- Implemented runtime gating and approval flow in `ChatSession`: tools are blocked if disabled or disallowed by mode, ASK triggers a yellow approval card in the chat (`ChatFormatter.requestToolApproval`) which returns `APPROVED` or `CANCELLED`, and `describe_tool` system-tool returns schema/details on demand.

### Testing
- Ran `git diff --check` to validate whitespace/format issues which returned no problems (success).
- Attempted to run `./gradlew :app:compileJava` to compile Java sources but the Gradle wrapper download is blocked in this environment by a network proxy (HTTP 403), so a full compile could not be completed (failure due to environment, not code).
- No automated unit tests were available/executed in this environment; manual runtime tests are recommended once the build environment can download Gradle and run the project.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69963f546adc83339df1583924944ba1)